### PR TITLE
Adds interruptable delay for standard sound output.

### DIFF
--- a/LISY35/Solenoids/interrupt_delay.c
+++ b/LISY35/Solenoids/interrupt_delay.c
@@ -1,0 +1,97 @@
+/*
+ * File:   interrupt_delay.c
+ * Author: Jakob Foos
+ *
+ * Created on 9/4/2020 5:45:56 PM UTC
+ * "Created in MPLAB Xpress"
+ *
+ * Using code created by MPLAB Xpress Code Configurator
+ *
+ */
+
+#include "interrupt_delay.h"
+
+#include "def_coils.h"
+#include <stdint.h>
+#include <pic18f45k22.h>
+
+
+static volatile unsigned int TMR2_CountCallBack = 0;
+
+
+void TMR2_Initialize(void)
+{
+    // Set TMR2 to the options selected in the User Interface:
+    // ~1 ms period
+    // Not started yet!
+
+    // PR2 15; 
+    PR2 = 0x0F;
+
+    // TMR2 0; 
+    TMR2 = 0x00;
+
+    // Clearing IF flag before enabling the interrupt.
+    PIR1bits.TMR2IF = 0;
+
+    // Enabling TMR2 interrupt.
+    PIE1bits.TMR2IE = 1;
+
+    // T2CKPS 1:16; T2OUTPS 1:16; TMR2ON off; 
+    T2CON = 0x7A;
+    
+    // TMRI - low priority
+    IPR1bits.TMR2IP = 0;    
+
+}
+
+void TMR2_StartTimer(void)
+{
+    // Start the Timer by writing to TMRxON bit
+    T2CONbits.TMR2ON = 1;
+}
+
+void TMR2_StopTimer(void)
+{
+    // Stop the Timer by writing to TMRxON bit
+    T2CONbits.TMR2ON = 0;
+}
+
+void TMR2_ISR(void)
+{
+    
+
+    // clear the TMR2 interrupt flag
+    PIR1bits.TMR2IF = 0;
+
+    // callback function - called every 18th pass
+    if (++TMR2_CountCallBack >= TMR2_INTERRUPT_TICKER_FACTOR)
+    {
+        // Stop the Timer by writing to TMRxON bit
+        T2CONbits.TMR2ON = 0;
+        
+        // reset ticker counter
+        TMR2_CountCallBack = 0;
+    }
+}
+
+
+void delay_18ms_interruptable(void)
+{
+    // The 18 ms are defined in the header
+    
+    // Reset timer2
+    TMR2_CountCallBack = 0;
+    TMR2 = 0x00;
+    
+    TMR2_StartTimer();
+    
+    while(T2CONbits.TMR2ON);
+    
+    
+}
+
+void interrupt_delay(void)
+{
+    TMR2_StopTimer();
+}

--- a/LISY35/Solenoids/interrupt_delay.h
+++ b/LISY35/Solenoids/interrupt_delay.h
@@ -1,0 +1,37 @@
+/* 
+ * File:   interrupt_delay.h
+ * Author: Jakob Foos
+ *
+ * Created on 9/4/2020 5:21:08 PM UTC
+ * "Created in MPLAB Xpress"
+ *
+ *
+ * Uses code created with the MPLAB Xpress Code Configurator
+ *
+ */
+
+#ifndef INTERRUPT_DELAY_H
+#define INTERRUPT_DELAY_H
+
+// Define the length of the interruptable delay in ms. Default application wants 18 ms.
+#define TMR2_INTERRUPT_TICKER_FACTOR    18
+
+
+// General driver for TMR2 - made with MPLAB
+void TMR2_Initialize(void);
+
+void TMR2_StartTimer(void);
+
+void TMR2_StopTimer(void);
+
+void TMR2_ISR(void);
+
+
+// new functions
+void delay_18ms_interruptable(void);
+
+void interrupt_delay(void);
+
+
+
+#endif  /* INTERRUPT_DELAY_H */


### PR DESCRIPTION
Fixes the issue when a solenoid command arrives quickly after a sound command.

The delay for interruptable_delay() is set to 18 ms by default. This can be edited in the header file, or easily be adapted to variable delay lengths.



Additionally PLL was disabled, but that did not improve anything. Compiles with XC8 (2.05) results in a running version, but only the four feature lamps with adress 0 are working, the rest is turned off.